### PR TITLE
Add dutch (nl) translation strings

### DIFF
--- a/resources/nl.lproj/Localizable.strings
+++ b/resources/nl.lproj/Localizable.strings
@@ -1,0 +1,72 @@
+/* No comment provided by engineer. */
+"%@ cannot start while another copy is running." = "%@ kan niet starten als er al een kopie geactiveerd is.";
+
+/* No comment provided by engineer. */
+"%@ is already running." = "%@ is al geactiveerd.";
+
+/* No comment provided by engineer. */
+"App" = "App";
+
+/* check box next to the 'Check for updates' button */
+"Automatically" = "Automatisch";
+
+/* No comment provided by engineer. */
+"Check for updates" = “Controleren op updates";
+
+/* No comment provided by engineer. */
+"For settings, click the icon in the menu bar" = "Voor voorkeuren, klik op het icoon in de menubalk";
+
+/* text shown when the menu bar icon is hidden */
+"MENU_HIDDEN_TEXT" = "Het icoon van Scroll Reverser is verwijderd uit de menubalk. Herstart Scroll Reverser vanuit Finder om het icoon te herstellen wanneer gewenst.";
+
+/* No comment provided by engineer. */
+"OK" = "OK";
+
+/* No comment provided by engineer. */
+"Preferences" = "Voorkeuren";
+
+/* No comment provided by engineer. */
+"Quit" = "Stoppen";
+
+/* No comment provided by engineer. */
+"Quit Scroll Reverser" = "Scroll Reverser Stoppen";
+
+/* No comment provided by engineer. */
+"Reverse Horizontal" = "Horizontaal Omkeren";
+
+/* No comment provided by engineer. */
+"Reverse Mouse" = "Muis Omkeren";
+
+/* No comment provided by engineer. */
+"Reverse Scrolling" = "Scrollen Omkeren";
+
+/* No comment provided by engineer. */
+"Reverse Tablet" = "Tablet Omkeren";
+
+/* No comment provided by engineer. */
+"Reverse Trackpad" = "Trackpad Omkeren";
+
+/* No comment provided by engineer. */
+"Reverse Vertical" = "Verticaal Omkeren";
+
+/* No comment provided by engineer. */
+"Scroll Reverser is now running!" = "Scroll Reverser is nu geactiveerd!";
+
+/* No comment provided by engineer. */
+"Scrolling" = "Scrollen";
+
+/* No comment provided by engineer. */
+"Scrolling Axes" = "Scrolrichtingen";
+
+/* No comment provided by engineer. */
+"Scrolling Devices" = "Scrolapparaten";
+
+/* No comment provided by engineer. */
+"Show in menu bar" = "Weergeven in menubalk";
+
+/* No comment provided by engineer. */
+"Start at login" = "Starten na inloggen";
+
+/* No comment provided by engineer. */
+"Status Icon Hidden" = "Statusicoon Verborgen";
+


### PR DESCRIPTION
I've added dutch translations in [./resources/nl.lproj/Localizable.strings](https://github.com/erikhuizinga/Scroll-Reverser/blob/dutch/resources/nl.lproj/Localizable.strings), which is the first step to address #35. The implemented is to be done by @invariant.