### PR TITLE
Reduce occurrence of multiple authorization services dialogs

### DIFF
--- a/MouseTap.m
+++ b/MouseTap.m
@@ -251,7 +251,7 @@ static CGEventRef callback(CGEventTapProxy proxy,
     lastSource=0;
     
     // passive tap
-    CGEventMask passiveEventMask=0;
+    CGEventMask passiveEventMask=NSEventMaskGesture;
     passiveTapPort=(CFMachPortRef)CGEventTapCreate(kCGSessionEventTap,
                                                    kCGTailAppendEventTap,
                                                    kCGEventTapOptionListenOnly,
@@ -262,7 +262,7 @@ static CGEventRef callback(CGEventTapProxy proxy,
     CFRunLoopAddSource(CFRunLoopGetMain(), passiveTapSource, kCFRunLoopCommonModes);
     
     // active tap
-    CGEventMask activeEventMask=NSEventMaskGesture|NSScrollWheelMask;
+    CGEventMask activeEventMask=NSEventMaskScrollWheel;
     activeTapPort=(CFMachPortRef)CGEventTapCreate(kCGSessionEventTap,
 										   kCGTailAppendEventTap,
 										   kCGEventTapOptionDefault,


### PR DESCRIPTION
If the active tap handles an event in an authorization services dialog then it may generate a second authorisation services dialog.

We do not modify gesture events: handling these in the passive tap reduces the occurrence of this happening.

Fixes issue #26