### PR TITLE
[WIP] Support dark mode on Mojave

### DIFF
--- a/ScrollReverser-Info.plist
+++ b/ScrollReverser-Info.plist
@@ -32,6 +32,8 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>Application</string>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<false/>
 	<key>OSAScriptingDefinition</key>
 	<string>ScrollReverser.sdef</string>
 	<key>SUAllowsAutomaticUpdates</key>


### PR DESCRIPTION
According to [Apple docs](https://developer.apple.com/documentation/appkit/nsappearancecustomization/choosing_a_specific_appearance_for_your_app?language=objc), setting `NSRequiresAquaSystemAppearance` to `NO` in the Info.plist should enable an app to support dark mode, without needing to target the macOS 10.14 SDK. This is what I've done to support dark mode in Scroll Reverser.

The only problem is that I'm having issues testing that it works, probably because I only have Xcode 10 and I believe it may be causing issues. For that reason, this PR should be considered a WIP, as I haven't confirmed it actually works. Any help would be appreciated.